### PR TITLE
同時刻にtrainやtestするとエラー起きる問題を修正

### DIFF
--- a/farmer/ImageAnalyzer/utils/reporter.py
+++ b/farmer/ImageAnalyzer/utils/reporter.py
@@ -142,9 +142,6 @@ class Reporter(Callback):
             self._image_dir, "test"
         )
 
-        os.makedirs(self._root_dir, exist_ok=True)
-        os.makedirs(self._result_dir, exist_ok=True)
-        os.makedirs(self._image_dir, exist_ok=True)
         os.makedirs(self._image_train_dir, exist_ok=True)
         os.makedirs(self._image_validation_dir, exist_ok=True)
         os.makedirs(self.image_test_dir, exist_ok=True)


### PR DESCRIPTION
同時刻にtrainやtestすると実行時に同名のresultファイルが存在してエラーが出る問題を解消