### PR TITLE
Feature/early stopping

### DIFF
--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -59,6 +59,6 @@ train_colors:
     - 5
     - 10
     - 15
-early_stopping: True # True if using early_stopping to interruption
+early_stopping: yes # yes if using early_stopping to interruption
 patience: 5
 monitor: val_loss

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -63,5 +63,5 @@ cosine_decay: False # True if using cosine_decay for learning rate
 cosine_lr_max: 0.001
 cosine_lr_min: 0.0001
 early_stopping: True # True if using early_stopping to interruption
-patience: 5
+patience: 2
 monitor: val_loss

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -24,7 +24,7 @@ train_params:
 weights_info: 
     classes: # assign only when you use backbone weights
     weights: 
-epochs: 50
+epochs: 2
 augmentation:
   HorizontalFlip:
   PadIfNeeded:
@@ -59,9 +59,6 @@ train_colors:
     - 5
     - 10
     - 15
-cosine_decay: False # True if using cosine_decay for learning rate
-cosine_lr_max: 0.001
-cosine_lr_min: 0.0001
 early_stopping: True # True if using early_stopping to interruption
-patience: 2
+patience: 5
 monitor: val_loss

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -24,7 +24,7 @@ train_params:
 weights_info: 
     classes: # assign only when you use backbone weights
     weights: 
-epochs: 2
+epochs: 50
 augmentation:
   HorizontalFlip:
   PadIfNeeded:
@@ -59,3 +59,9 @@ train_colors:
     - 5
     - 10
     - 15
+cosine_decay: False # True if using cosine_decay for learning rate
+cosine_lr_max: 0.001
+cosine_lr_min: 0.0001
+early_stopping: False # True if using early_stopping to interruption
+patience: 5
+monitor: val_loss

--- a/example/yamls/segmentation.yaml
+++ b/example/yamls/segmentation.yaml
@@ -62,6 +62,6 @@ train_colors:
 cosine_decay: False # True if using cosine_decay for learning rate
 cosine_lr_max: 0.001
 cosine_lr_min: 0.0001
-early_stopping: False # True if using early_stopping to interruption
+early_stopping: True # True if using early_stopping to interruption
 patience: 5
 monitor: val_loss

--- a/farmer/domain/model/trainer_model.py
+++ b/farmer/domain/model/trainer_model.py
@@ -39,7 +39,7 @@ class Trainer(Config, ImageLoader):
     cosine_lr_max: int = 0.01
     cosine_lr_min: int = 0.001
     early_stopping: bool = False
-    patience: int = 5
+    patience: int = 10
     monitor: str = "val_loss"
     optuna: bool = False
     seed: int = 1

--- a/farmer/domain/model/trainer_model.py
+++ b/farmer/domain/model/trainer_model.py
@@ -38,6 +38,9 @@ class Trainer(Config, ImageLoader):
     cosine_decay: bool = False
     cosine_lr_max: int = 0.01
     cosine_lr_min: int = 0.001
+    early_stopping: bool = False
+    patience: int = 5
+    monitor: str = "val_loss"
     optuna: bool = False
     seed: int = 1
     n_trials: int = 10

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -165,7 +165,6 @@ class TrainTask:
                 self.config.monitor,
                 self.config.patience,
                 mode = 'auto'
-
             )
             callbacks.append(early_stopping)
 

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -92,6 +92,13 @@ class TrainTask:
             scheduler = keras.callbacks.ReduceLROnPlateau(
                 factor=0.5, patience=10, verbose=1)
 
+        # Early Stoppoing
+        if self.config.early_stopping:
+            early_stopping = keras.callbacks.EarlyStopping(
+                self.config.patience,
+                self.config.monitor
+            )
+
         # Plot History
         # result_dir/learning/
         learning_path = self.config.learning_path
@@ -101,7 +108,7 @@ class TrainTask:
             ['loss', 'acc', 'iou_score', 'f1-score']
         )
 
-        callbacks = [checkpoint, scheduler, plot_history]
+        callbacks = [checkpoint, scheduler, plot_history, early_stopping]
 
         if self.config.task == ncc.tasks.Task.SEMANTIC_SEGMENTATION:
             # Plot IoU History

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -96,14 +96,19 @@ class TrainTask:
         if self.config.early_stopping:
             early_stopping = keras.callbacks.EarlyStopping(
                 self.config.patience,
-                self.config.monitor
+                self.config.monitor,
+                min_delta=0,
+                verbose=2,
+                mode='auto',
+                baseline=None,
+                restore_best_weights=False
             )
         else:
             early_stopping = keras.callbacks.EarlyStopping(
                 monitor='val_loss',
                 min_delta=0,
                 patience=10,
-                verbose=1,
+                verbose=2,
                 mode='auto',
                 baseline=None,
                 restore_best_weights=False

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -105,7 +105,7 @@ class TrainTask:
                 patience=10,
                 verbose=1,
                 mode='auto',
-                baseline=None
+                baseline=None,
                 restore_best_weights=False
             )
 

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -98,6 +98,16 @@ class TrainTask:
                 self.config.patience,
                 self.config.monitor
             )
+        else:
+            early_stopping = keras.callbacks.EarlyStopping(
+                monitor='val_loss',
+                min_delta=0,
+                patience=10,
+                verbose=1,
+                mode='auto',
+                baseline=None
+                restore_best_weights=False
+            )
 
         # Plot History
         # result_dir/learning/

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -95,23 +95,13 @@ class TrainTask:
         # Early Stoppoing
         if self.config.early_stopping:
             early_stopping = keras.callbacks.EarlyStopping(
-                self.config.patience,
                 self.config.monitor,
-                min_delta=0,
-                verbose=2,
-                mode='auto',
-                baseline=None,
-                restore_best_weights=False
+                self.config.patience
             )
         else:
             early_stopping = keras.callbacks.EarlyStopping(
                 monitor='val_loss',
-                min_delta=0,
-                patience=10,
-                verbose=2,
-                mode='auto',
-                baseline=None,
-                restore_best_weights=False
+                patience=10
             )
 
         # Plot History

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -162,9 +162,9 @@ class TrainTask:
         # Early Stoppoing
         if self.config.early_stopping:
             early_stopping = keras.callbacks.EarlyStopping(
-                self.config.monitor,
-                self.config.patience,
-                mode = 'auto'
+                monitor=self.config.monitor,
+                patience=self.config.patience,
+                mode='auto'
             )
             callbacks.append(early_stopping)
 

--- a/farmer/domain/tasks/train_task.py
+++ b/farmer/domain/tasks/train_task.py
@@ -92,18 +92,6 @@ class TrainTask:
             scheduler = keras.callbacks.ReduceLROnPlateau(
                 factor=0.5, patience=10, verbose=1)
 
-        # Early Stoppoing
-        if self.config.early_stopping:
-            early_stopping = keras.callbacks.EarlyStopping(
-                self.config.monitor,
-                self.config.patience
-            )
-        else:
-            early_stopping = keras.callbacks.EarlyStopping(
-                monitor='val_loss',
-                patience=10
-            )
-
         # Plot History
         # result_dir/learning/
         learning_path = self.config.learning_path
@@ -113,7 +101,7 @@ class TrainTask:
             ['loss', 'acc', 'iou_score', 'f1-score']
         )
 
-        callbacks = [checkpoint, scheduler, plot_history, early_stopping]
+        callbacks = [checkpoint, scheduler, plot_history]
 
         if self.config.task == ncc.tasks.Task.SEMANTIC_SEGMENTATION:
             # Plot IoU History
@@ -170,6 +158,17 @@ class TrainTask:
                 title=self.config.model_name,
             )
             callbacks.append(slack_logging)
+
+        # Early Stoppoing
+        if self.config.early_stopping:
+            early_stopping = keras.callbacks.EarlyStopping(
+                self.config.monitor,
+                self.config.patience,
+                mode = 'auto'
+
+            )
+            callbacks.append(early_stopping)
+
         return callbacks
 
     def _do_model_optimization_task(


### PR DESCRIPTION
## Issueリンク
* https://github.com/aiorhiroki/farmer/issues/117

## 実行したこと
* keras.callbacksからEarlyStoppingの実装

## できるようになること（ユーザ目線）
* yamlにearly_stopping: True (またはyes)記載でEarlyStoppingの実行が可能。
* yamlのpatience: (default:10)を操作することで、何Epochの間変更がない場合にStopするかを決めることが可能。
* yamlのmonitor: (default:val_loss)を操作することで、どの指標を監視するかを変更可能。  

## 動作確認
* DL2上でのfarmer実行(patience:5の設定で、36Epoch目で学習終了）
* Git Hub Actionsでの動作

## 参考情報
* callbacksの最後にappendしないと実行されない可能性が高いため、trainer_task > _do_set_callbacks_taskの最終行に追加
* callbacks追加に際しては、出来るだけ途中に記載いただきたい
* Tensorflow のバージョン依存により、問題解消されている場合がある模様