### PR TITLE
optunaのresultのtrialディレクトリが正しい場所に出力されない不具合修正

### DIFF
--- a/farmer/domain/tasks/set_train_env_task.py
+++ b/farmer/domain/tasks/set_train_env_task.py
@@ -54,11 +54,14 @@ class SetTrainEnvTask:
         self.config.trial_number = trial.number
         self.config.trial_params = trial.params
         # result_dir/trial#/learning/
-        self.config.learning_path = self.config.learning_path.replace(
+        learning_path = os.path.join(self.config.result_path, self.config.learning_dir)
+        model_path = os.path.join(self.config.result_path, self.config.model_dir)
+        image_path = os.path.join(self.config.result_path, self.config.image_dir)
+        self.config.learning_path = learning_path.replace(
             "/learning", f"/trial{trial.number}/learning")
-        self.config.model_path = self.config.model_path.replace(
+        self.config.model_path = model_path.replace(
             "/model", f"/trial{trial.number}/model")
-        self.config.image_path = self.config.image_path.replace(
+        self.config.image_path = image_path.replace(
             "/image", f"/trial{trial.number}/image")
 
         def set_train_params(train_params: dict) -> dict:

--- a/farmer/domain/tasks/set_train_env_task.py
+++ b/farmer/domain/tasks/set_train_env_task.py
@@ -54,15 +54,12 @@ class SetTrainEnvTask:
         self.config.trial_number = trial.number
         self.config.trial_params = trial.params
         # result_dir/trial#/learning/
-        learning_path = os.path.join(self.config.result_path, self.config.learning_dir)
-        model_path = os.path.join(self.config.result_path, self.config.model_dir)
-        image_path = os.path.join(self.config.result_path, self.config.image_dir)
-        self.config.learning_path = learning_path.replace(
-            "/learning", f"/trial{trial.number}/learning")
-        self.config.model_path = model_path.replace(
-            "/model", f"/trial{trial.number}/model")
-        self.config.image_path = image_path.replace(
-            "/image", f"/trial{trial.number}/image")
+        self.config.learning_path = os.path.join(
+            self.config.result_path, f'trial{trial.number}', self.config.learning_dir)
+        self.config.model_path = os.path.join(
+            self.config.result_path, f'trial{trial.number}', self.config.model_dir)
+        self.config.image_path = os.path.join(
+            self.config.result_path, f'trial{trial.number}', self.config.image_dir)
 
         def set_train_params(train_params: dict) -> dict:
             for key, val in train_params.items():


### PR DESCRIPTION
### 変更点
- trialディレクトリの中にtrialディレクトリが出力されてしまうので、set_train_env_taskでoptunaの結果格納用のパス設定を適切なものにしました。

### 問題点
- 特になし

### 備考
- 動作確認済み