### PR TITLE
学習データの平均、標準偏差の計算のリファクタリング

### DIFF
--- a/farmer/domain/tasks/eda_task.py
+++ b/farmer/domain/tasks/eda_task.py
@@ -5,7 +5,7 @@ import json
 import numpy as np
 import cv2
 import random
-
+from tqdm import trange
 
 class EdaTask:
     def __init__(self, config):
@@ -66,7 +66,7 @@ class EdaTask:
         """
         train_set, _, _ = annotation_set
         if self.config.input_data_type == 'image' and self.config.mean_std:
-            if len(train_set) <= 0:
+            if len(train_set) == 0:
                 return
         else:
             return
@@ -74,13 +74,14 @@ class EdaTask:
             return
         means = []
         pix_pow = np.zeros(3)
-        for input_file, label in train_set:
+        for i in trange(len(train_set)):
+            input_file, label = train_set[i]
             x = cv2.imread(input_file)
             x = cv2.resize(x, (self.config.width, self.config.height))
             x = x / 255.  # 正規化してからmean,stdを計算する
             means.append(np.mean(x, axis=(0, 1)))
             pix_pow += np.sum(np.power(x, 2), axis=(0, 1))
-        pix_num = self.config.height *  self.config.width * len(sample_train_set)
+        pix_num = self.config.height *  self.config.width * len(train_set)
         mean = np.mean(means, axis=(0))
         var_pix = (pix_pow / pix_num) - np.power(mean, 2) 
         std = np.sqrt(var_pix)

--- a/farmer/domain/tasks/eda_task.py
+++ b/farmer/domain/tasks/eda_task.py
@@ -66,24 +66,24 @@ class EdaTask:
         """
         train_set, _, _ = annotation_set
         if self.config.input_data_type == 'image' and self.config.mean_std:
-            if len(train_set) > 2000:
-                sample_train_set = random.sample(train_set, 2000)
-            elif len(train_set) > 0:
-                sample_train_set = train_set
-            else:
+            if len(train_set) <= 0:
                 return
         else:
             return
         if len(self.config.mean) > 0 and len(self.config.std) > 0:
             return
-        bgr_images = []
-        for input_file, label in sample_train_set:
+        means = []
+        pix_pow = np.zeros(3)
+        for input_file, label in train_set:
             x = cv2.imread(input_file)
             x = cv2.resize(x, (self.config.width, self.config.height))
             x = x / 255.  # 正規化してからmean,stdを計算する
-            bgr_images.append(x)
-        mean = np.mean(bgr_images, axis=(0, 1, 2))
-        std = np.std(bgr_images, axis=(0, 1, 2))
+            means.append(np.mean(x, axis=(0, 1)))
+            pix_pow += np.sum(np.power(x, 2), axis=(0, 1))
+        pix_num = self.config.height *  self.config.width * len(sample_train_set)
+        mean = np.mean(means, axis=(0))
+        var_pix = (pix_pow / pix_num) - np.power(mean, 2) 
+        std = np.sqrt(var_pix)
         # convert BGR to RGB
         self.config.mean = mean[::-1]
         self.config.std = std[::-1]

--- a/farmer/domain/tasks/eda_task.py
+++ b/farmer/domain/tasks/eda_task.py
@@ -7,6 +7,7 @@ import cv2
 import random
 from tqdm import trange
 
+
 class EdaTask:
     def __init__(self, config):
         self.config = config
@@ -68,23 +69,22 @@ class EdaTask:
         if self.config.input_data_type == 'image' and self.config.mean_std:
             if len(train_set) == 0:
                 return
-        else:
-            return
-        if len(self.config.mean) > 0 and len(self.config.std) > 0:
-            return
-        means = []
-        pix_pow = np.zeros(3)
-        for i in trange(len(train_set)):
-            input_file, label = train_set[i]
-            x = cv2.imread(input_file)
-            x = cv2.resize(x, (self.config.width, self.config.height))
-            x = x / 255.  # 正規化してからmean,stdを計算する
-            means.append(np.mean(x, axis=(0, 1)))
-            pix_pow += np.sum(np.power(x, 2), axis=(0, 1))
-        pix_num = self.config.height *  self.config.width * len(train_set)
-        mean = np.mean(means, axis=(0))
-        var_pix = (pix_pow / pix_num) - np.power(mean, 2) 
-        std = np.sqrt(var_pix)
-        # convert BGR to RGB
-        self.config.mean = mean[::-1]
-        self.config.std = std[::-1]
+            elif len(self.config.mean) > 0 and len(self.config.std) > 0:
+                return
+
+            means = []
+            pix_pow = np.zeros(3)
+            for i in trange(len(train_set)):
+                input_file, label = train_set[i]
+                x = cv2.imread(input_file)
+                x = cv2.resize(x, (self.config.width, self.config.height))
+                x = x / 255.  # 正規化してからmean,stdを計算する
+                means.append(np.mean(x, axis=(0, 1)))
+                pix_pow += np.sum(np.power(x, 2), axis=(0, 1))
+            pix_num = self.config.height *  self.config.width * len(train_set)
+            mean = np.mean(means, axis=(0))
+            var_pix = (pix_pow / pix_num) - np.power(mean, 2)
+            std = np.sqrt(var_pix)
+            # convert BGR to RGB
+            self.config.mean = mean[::-1]
+            self.config.std = std[::-1]


### PR DESCRIPTION
### 変更点
- 2000枚分の画像情報を蓄積して平均、標準偏差を計算していたのを、画像情報は蓄積せずに計算に必要な情報だけ抽出して保持して計算するようにしました。
### 問題点
- 特になし
### 備考
- 動作確認済み
