### PR TITLE
log cosh dice loss

### DIFF
--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -45,7 +45,7 @@ def log_cosh_tversky_loss(gt, pr, alpha=0.3, beta=0.7, class_weights=1.):
 def log_cosh_focal_tversky_loss(gt, pr, alpha=0.3, beta=0.7, gamma=1.3, class_weights=1.):
     x = focal_tversky_loss(gt, pr, alpha, beta, gamma, class_weights)
     return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
-    
+
 
 def _tp_fp_fn(gt, pr):
     pr = tf.clip_by_value(pr, SMOOTH, 1 - SMOOTH)
@@ -73,4 +73,4 @@ def _iou_index(gt, pr):
 
 def _tversky_index(gt, pr, alpha, beta):
     tp, fp, fn = _tp_fp_fn(gt, pr)
-    return (tp + SMOOTH) / (tp + alpha*fp + beta*fn + SMOOTH)
+    return (tp + SMOOTH) / (tp + alpha * fp + beta * fn + SMOOTH)

--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -32,6 +32,21 @@ def categorical_focal_loss(gt, pr, gamma=2.0, alpha=0.25, class_weights=1.):
     return tf.reduce_mean(loss)
 
 
+def log_cosh_dice_loss(gt, pr, beta=1, class_weights=1.):
+    x = dice_loss(gt, pr, beta, class_weights)
+    return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
+
+
+def log_cosh_tversky_loss(gt, pr, alpha=0.3, beta=0.7, class_weights=1.):
+    x = tversky_loss(gt, pr, alpha, beta, class_weights)
+    return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
+
+
+def log_cosh_focal_tversky_loss(gt, pr, alpha=0.3, beta=0.7, gamma=1.3, class_weights=1.):
+    x = focal_tversky_loss(gt, pr, alpha, beta, gamma, class_weights=)
+    return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
+    
+
 def _tp_fp_fn(gt, pr):
     pr = tf.clip_by_value(pr, SMOOTH, 1 - SMOOTH)
     reduce_axes = [0, 1, 2]

--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -43,7 +43,7 @@ def log_cosh_tversky_loss(gt, pr, alpha=0.3, beta=0.7, class_weights=1.):
 
 
 def log_cosh_focal_tversky_loss(gt, pr, alpha=0.3, beta=0.7, gamma=1.3, class_weights=1.):
-    x = focal_tversky_loss(gt, pr, alpha, beta, gamma, class_weights=)
+    x = focal_tversky_loss(gt, pr, alpha, beta, gamma, class_weights)
     return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
     
 

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -1,4 +1,3 @@
-import tensorflow as tf
 import segmentation_models
 from segmentation_models.base import Loss
 from segmentation_models.losses import CategoricalCELoss

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 import segmentation_models
 from segmentation_models.base import Loss
 from segmentation_models.losses import CategoricalCELoss
@@ -82,6 +83,57 @@ class CategoricalFocalLoss(Loss):
             gt,
             pr,
             alpha=self.alpha,
+            gamma=self.gamma,
+            class_weights=self.class_weights
+        )
+
+
+class LogCoshDiceLoss(Loss):
+    def __init__(self, beta=1, class_weights=None):
+        super().__init__(name='log_cosh_dice_loss')
+        self.beta = beta
+        self.class_weights = class_weights if class_weights is not None else 1
+
+    def __call__(self, gt, pr):
+        return F.log_cosh_dice_loss(
+            gt=gt,
+            pr=pr,
+            beta=self.beta,
+            class_weights=self.class_weights
+        )
+
+
+class LogCoshTverskyLoss(Loss):
+    def __init__(self, alpha=0.3, beta=0.7, class_weights=None):
+        super().__init__(name='log_cosh_tversky_loss')
+        self.alpha = alpha
+        self.beta = beta
+        self.class_weights = class_weights if class_weights is not None else 1.
+
+    def __call__(self, gt, pr):
+        return F.log_cosh_tversky_loss(
+            gt=gt,
+            pr=pr,
+            alpha=self.alpha,
+            beta=self.beta,
+            class_weights=self.class_weights
+        )
+
+
+class LogCoshFocalTverskyLoss(Loss):
+    def __init__(self, alpha=0.3, beta=0.7, gamma=1.3, class_weights=None):
+        super().__init__(name='log_cosh_focal_tversky_loss')
+        self.alpha = alpha
+        self.beta = beta
+        self.gamma = gamma
+        self.class_weights = class_weights if class_weights is not None else 1.
+
+    def __call__(self, gt, pr):
+        return F.log_cosh_focal_tversky_loss(
+            gt=gt,
+            pr=pr,
+            alpha=self.alpha,
+            beta=self.beta,
             gamma=self.gamma,
             class_weights=self.class_weights
         )

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 import segmentation_models
 from segmentation_models.base import Loss
 from segmentation_models.losses import CategoricalCELoss
@@ -136,3 +137,14 @@ class LogCoshFocalTverskyLoss(Loss):
             gamma=self.gamma,
             class_weights=self.class_weights
         )
+
+
+class LogCoshLoss(Loss):
+    def __init__(self, base_loss, **kwargs):
+        super().__init__(name=f'log_cosh_{base_loss}')
+        self.loss = getattr(F, base_loss)
+        self.kwargs = kwargs
+
+    def __call__(self, gt, pr):
+        x = self.loss(gt, pr, **self.kwargs)
+        return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)


### PR DESCRIPTION
## 変更点
- LogCoshDiceLossを追加
    - dice_loss, tversky_loss, focal_tversky_lossを合わせて追加

## 問題点
- ### `los_cosh_focal_tversky_loss` を使うとlossとiouが `nan` になる
    - focal_tversky_lossもnanになりました

-  dice_loss, tversky_loss, focal_tversky_lossそれぞれ別のfunctional, Lossで作りましたが、既存のlossにただ演算するだけなので、1つにまとめた方がいいですか？

```python
class LogCoshLoss(Loss):
    def __init__(self, base_loss, **kwargs):
        super().__init__(name=f'log_cosh_{base_loss}')
        self.loss = getattr(F, base_loss)
        self.kwargs = kwargs

    def __call__(self, gt, pr):
        x = self.loss(gt, pr, **self.kwargs)
        return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
```

のように

## reference
https://arxiv.org/abs/2006.14822