### PR TITLE
DeeplabV3 w/ ResNeSt family

### DIFF
--- a/farmer/domain/tasks/build_model_task.py
+++ b/farmer/domain/tasks/build_model_task.py
@@ -57,8 +57,8 @@ class BuildModelTask:
                     height=height,
                     width=width
                 )
-            elif model_name == "dilated_xception" and xception_shape_condition:
-                model = models.dilated_xception(
+            elif model_name == "aligned_xception" and xception_shape_condition:
+                model = models.aligned_xception(
                     nb_classes=nb_classes,
                     height=height,
                     width=width,
@@ -231,7 +231,7 @@ class BuildModelTask:
                         class_indexes=list(range(1, self.config.nb_classes))),
                     segmentation_models.metrics.FScore(
                         class_indexes=list(range(1, self.config.nb_classes)))
-                    ],
+                ],
 
             model.compile(optimizer, loss, metrics)
         return model

--- a/farmer/ncc/models/Deeplabv3.py
+++ b/farmer/ncc/models/Deeplabv3.py
@@ -129,11 +129,12 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
 
     elif backbone.startswith('resnest'):
         height, width = input_shape[0:2]
-        base_model = resnest(
+        base_model, skip1 = resnest(
             model_name=backbone,
             height=height,
             width=width,
-            include_top=False
+            include_top=False, 
+            return_skip=True,
         )
 
     else:
@@ -141,6 +142,7 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
                          '`xception`, `mobilenetv2` or `resnest50`')
 
     x = base_model.output
+    print(x, skip1)
     # end of feature extractor
 
     # branching for Atrous Spatial Pyramid Pooling
@@ -186,7 +188,7 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
     x = Dropout(0.1)(x)
 
     # DeepLab v.3+ decoder
-    if backbone == 'xception':
+    if backbone == 'xception' or backbone.startswith('resnest'):
         # Feature projection
         # x4 (x2) block
         size_before2 = tf.keras.backend.int_shape(x)

--- a/farmer/ncc/models/Deeplabv3.py
+++ b/farmer/ncc/models/Deeplabv3.py
@@ -101,7 +101,7 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
         weights = weights_info["weights"]
 
     if input_tensor is None:
-        img_input = Input(shape=input_shape)
+        img_input = Input(shape=input_shape, name="image_input")
     else:
         img_input = input_tensor
 
@@ -139,6 +139,7 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
             include_top=False,
             return_skip=True,
         )
+        img_input = base_model.inputs[0]
 
     else:
         raise ValueError('The `backbone` argument should be either '

--- a/farmer/ncc/models/Deeplabv3.py
+++ b/farmer/ncc/models/Deeplabv3.py
@@ -26,22 +26,17 @@ import os
 import tensorflow as tf
 
 from tensorflow.python.keras.models import Model
-from tensorflow.python.keras import layers
 from tensorflow.python.keras.layers import Input
 from tensorflow.python.keras.layers import Lambda
 from tensorflow.python.keras.layers import Activation
 from tensorflow.python.keras.layers import Concatenate
-from tensorflow.python.keras.layers import Add
 from tensorflow.python.keras.layers import Dropout
 from tensorflow.python.keras.layers import BatchNormalization
 from tensorflow.python.keras.layers import Conv2D
-from tensorflow.python.keras.layers import DepthwiseConv2D
-from tensorflow.python.keras.layers import ZeroPadding2D
 from tensorflow.python.keras.layers import GlobalAveragePooling2D
 from tensorflow.python.keras.utils.layer_utils import get_source_inputs
 from tensorflow.python.keras.utils.data_utils import get_file
 from tensorflow.python.keras import backend as K
-from tensorflow.python.keras.activations import relu
 from tensorflow.python.keras.applications.imagenet_utils import preprocess_input
 
 from .functional import SepConv_BN
@@ -99,12 +94,12 @@ def Deeplabv3(weights_info=None, input_tensor=None, input_shape=(512, 512, 3), c
     if not (backbone in {'xception', 'mobilenetv2'}):
         raise ValueError('The `backbone` argument should be either '
                          '`xception`  or `mobilenetv2` ')
-    
+
     if weights_info.get("weights") is None:
         weights = 'pascal_voc'
     else:
         weights = weights_info["weights"]
-    
+
     if input_tensor is None:
         img_input = Input(shape=input_shape)
     else:
@@ -117,29 +112,27 @@ def Deeplabv3(weights_info=None, input_tensor=None, input_shape=(512, 512, 3), c
 
     if backbone == 'xception':
         base_model, skip1 = DilatedXception(
-            input_tensor=img_input, 
-            input_shape=input_shape, 
-            weights_info=weights_info, 
-            OS=OS, 
-            return_skip=True, 
+            input_tensor=img_input,
+            input_shape=input_shape,
+            weights_info=weights_info,
+            OS=OS,
+            return_skip=True,
             include_top=False
         )
 
     else:
         base_model = MobileNetV2(
-            input_tensor=img_input, 
-            input_shape=input_shape, 
-            weights_info=weights_info, 
-            OS=OS, 
+            input_tensor=img_input,
+            input_shape=input_shape,
+            weights_info=weights_info,
+            OS=OS,
             include_top=False
         )
-    
-    x = base_model.output
 
+    x = base_model.output
     # end of feature extractor
 
     # branching for Atrous Spatial Pyramid Pooling
-
     # Image Feature branch
     shape_before = tf.shape(x)
     b4 = GlobalAveragePooling2D()(x)
@@ -181,8 +174,8 @@ def Deeplabv3(weights_info=None, input_tensor=None, input_shape=(512, 512, 3), c
     x = BatchNormalization(name='concat_projection_BN', epsilon=1e-5)(x)
     x = Activation('relu')(x)
     x = Dropout(0.1)(x)
-    # DeepLab v.3+ decoder
 
+    # DeepLab v.3+ decoder
     if backbone == 'xception':
         # Feature projection
         # x4 (x2) block
@@ -252,13 +245,3 @@ def Deeplabv3(weights_info=None, input_tensor=None, input_shape=(512, 512, 3), c
         if weights_info.get("classes") is None:
             model.load_weights(weights)
     return model
-
-
-def preprocess_input(x):
-    """Preprocesses a numpy array encoding a batch of images.
-    # Arguments
-        x: a 4D numpy array consists of RGB values within [0, 255].
-    # Returns
-        Input array scaled to [-1.,1.]
-    """
-    return preprocess_input(x, mode='tf')

--- a/farmer/ncc/models/Deeplabv3.py
+++ b/farmer/ncc/models/Deeplabv3.py
@@ -92,11 +92,14 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
 
     """
 
-    if not (backbone in {'xception', 'resnest50', 'mobilenetv2'}):
-        raise ValueError('The `backbone` argument should be either '
-                         '`xception`  or `mobilenetv2` ')
+    # if not (backbone in {'xception', 'resnest50', 'mobilenetv2'}):
+    #     raise ValueError('The `backbone` argument should be either '
+    #                      '`xception`  or `mobilenetv2` ')
 
-    weights = weights_info["weights"]
+    if weights_info is None:
+        weights = None
+    else:
+        weights = weights_info["weights"]
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)
@@ -133,7 +136,7 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
             model_name=backbone,
             height=height,
             width=width,
-            include_top=False, 
+            include_top=False,
             return_skip=True,
         )
 
@@ -231,6 +234,9 @@ def Deeplabv3(weights_info={"weights": "pascal_voc"}, input_tensor=None, input_s
         x = Activation(activation)(x)
 
     model = Model(inputs, x, name='deeplabv3plus')
+
+    if weights is None:
+        return model
 
     # load weights
     if weights == 'pascal_voc':

--- a/farmer/ncc/models/__init__.py
+++ b/farmer/ncc/models/__init__.py
@@ -1,7 +1,7 @@
 from .xception import xception
 from .mobilenet import mobilenet
 from .Deeplabv3 import Deeplabv3
-from .dilated_xception import DilatedXception, dilated_xception
+from .aligned_xception import AlignedXception, aligned_xception
 from .mobilenetv2 import MobileNetV2, mobilenet_v2
 from .efficientnet import EfficientNet
 from .resnest import resnest

--- a/farmer/ncc/models/aligned_xception.py
+++ b/farmer/ncc/models/aligned_xception.py
@@ -93,7 +93,7 @@ def _xception_block(inputs, depth_list, prefix, skip_connection_type, stride,
     return outputs, skip
 
 
-def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), weights_info=None, OS=16, return_skip=False, include_top=True):
+def AlignedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), weights_info=None, OS=16, return_skip=False, include_top=True):
     """ Instantiates the Deeplabv3+ architecture
 
     Optionally loads weights pre-trained
@@ -125,18 +125,18 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
 
         elif weights_info["weights"] in {'pascal_voc', 'cityscapes', None}:
             weights = weights_info["weights"]
-        
+
         elif os.path.exists(weights_info["weights"]):
             weights = weights_info["weights"]
             if weights_info.get("classes") is not None:
                 classes = int(weights_info["classes"])
-        
+
         else:
             raise ValueError('The `weights` should be either '
-                            '`None` (random initialization), `pascal_voc`, `cityscapes`, '
-                            'original weights path (pre-training on original data), '
-                            'or the path to the weights file to be loaded and'
-                            '`classes` should be number of original weights output units')
+                             '`None` (random initialization), `pascal_voc`, `cityscapes`, '
+                             'original weights path (pre-training on original data), '
+                             'or the path to the weights file to be loaded and'
+                             '`classes` should be number of original weights output units')
     else:
         weights = None
         if classes is None:
@@ -157,7 +157,7 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
         exit_block_rates = (1, 2)
 
     x = Conv2D(32, (3, 3), strides=(2, 2),
-                name='entry_flow_conv1_1', use_bias=False, padding='same')(img_input)
+               name='entry_flow_conv1_1', use_bias=False, padding='same')(img_input)
     x = BatchNormalization(name='entry_flow_conv1_1_BN')(x)
     x = Activation('relu')(x)
 
@@ -166,30 +166,30 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
     x = Activation('relu')(x)
 
     x, _ = _xception_block(x, [128, 128, 128], 'entry_flow_block1',
-                        skip_connection_type='conv', stride=2,
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=2,
+                           depth_activation=False)
     x, skip = _xception_block(x, [256, 256, 256], 'entry_flow_block2',
-                                skip_connection_type='conv', stride=2,
-                                depth_activation=False)
+                              skip_connection_type='conv', stride=2,
+                              depth_activation=False)
 
     x, _ = _xception_block(x, [728, 728, 728], 'entry_flow_block3',
-                        skip_connection_type='conv', stride=entry_block3_stride,
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=entry_block3_stride,
+                           depth_activation=False)
     for i in range(16):
         x, _ = _xception_block(x, [728, 728, 728], 'middle_flow_unit_{}'.format(i + 1),
-                            skip_connection_type='sum', stride=1, rate=middle_block_rate,
-                            depth_activation=False)
+                               skip_connection_type='sum', stride=1, rate=middle_block_rate,
+                               depth_activation=False)
 
     x, _ = _xception_block(x, [728, 1024, 1024], 'exit_flow_block1',
-                        skip_connection_type='conv', stride=1, rate=exit_block_rates[0],
-                        depth_activation=False)
+                           skip_connection_type='conv', stride=1, rate=exit_block_rates[0],
+                           depth_activation=False)
     x, _ = _xception_block(x, [1536, 1536, 2048], 'exit_flow_block2',
-                        skip_connection_type='none', stride=1, rate=exit_block_rates[1],
-                        depth_activation=True)
+                           skip_connection_type='none', stride=1, rate=exit_block_rates[1],
+                           depth_activation=True)
 
     x = GlobalAveragePooling2D()(x)
     x = Dense(classes, activation='softmax')(x)
-    
+
     # Ensure that the model takes into account
     # any potential predecessors of `input_tensor`.
     if input_tensor is not None:
@@ -208,17 +208,18 @@ def DilatedXception(classes=10, input_tensor=None, input_shape=(512, 512, 3), we
     # get model before FC layer
     if not include_top:
         model = Model(
-            inputs=model.input, 
+            inputs=model.input,
             outputs=model.get_layer(index=-3).output
         )
-    
+
     if return_skip:
         return model, skip
     else:
         return model
 
-def dilated_xception(nb_classes, height=512, width=512, weights_info=None):
-    base_model = DilatedXception(
+
+def aligned_xception(nb_classes, height=512, width=512, weights_info=None):
+    base_model = AlignedXception(
         classes=nb_classes,
         input_shape=(height, width, 3),
         weights_info=weights_info,
@@ -230,4 +231,3 @@ def dilated_xception(nb_classes, height=512, width=512, weights_info=None):
     model = Model(base_model.input, predictions)
 
     return model
-

--- a/farmer/ncc/models/resnest.py
+++ b/farmer/ncc/models/resnest.py
@@ -1,3 +1,7 @@
+"""from this repository
+https://github.com/QiaoranC/tf_ResNeSt_RegNet_model
+"""
+
 import tensorflow as tf
 # tf.enable_eager_execution()
 # tf.compat.v1.enable_eager_execution()
@@ -105,7 +109,7 @@ class ResNest:
     def __init__(self, verbose=False, input_shape=(224, 224, 3), active="relu", nb_classes=81,
                  dropout_rate=0.2, fc_activation=None, blocks_set=[3, 4, 6, 3], radix=2, groups=1,
                  bottleneck_width=64, deep_stem=True, stem_width=32, block_expansion=4, avg_down=True,
-                 avd=True, avd_first=False, preact=False, using_basic_block=False, using_cb=False):
+                 avd=True, avd_first=False, preact=False, using_basic_block=False, using_cb=False, include_top=True):
         self.channel_axis = -1  # not for change
         self.verbose = verbose
         self.active = active  # default relu
@@ -131,6 +135,7 @@ class ResNest:
         self.preact = preact
         self.using_basic_block = using_basic_block
         self.using_cb = using_cb
+        self.include_top = include_top
 
     def _make_stem(self, input_tensor, stem_width=64, deep_stem=False):
         x = input_tensor
@@ -189,10 +194,8 @@ class ResNest:
         else:
             gap = x
 
-        # print('sum',gap.shape)
         gap = GlobalAveragePooling2D(data_format="channels_last")(gap)
         gap = tf.reshape(gap, [-1, 1, 1, filters])
-        # print('adaptive_avg_pool2d',gap.shape)
 
         reduction_factor = 4
         inter_channels = max(in_channels * radix // reduction_factor, 32)
@@ -263,7 +266,7 @@ class ResNest:
 
         if avd and not avd_first:
             x = avd_layer(x)
-            # print('can')
+
         x = Conv2D(filters * self.block_expansion, kernel_size=1, strides=1, padding="same", kernel_initializer="he_normal",
                    dilation_rate=self.dilation, use_bias=False, data_format="channels_last")(x)
         x = BatchNormalization(axis=self.channel_axis, epsilon=1.001e-5)(x)
@@ -317,7 +320,6 @@ class ResNest:
 
         if avd and not avd_first:
             x = avd_layer(x)
-            # print('can')
 
         x = BatchNormalization(axis=self.channel_axis, epsilon=1.001e-5)(x)
         x = Activation(self.active)(x)
@@ -331,24 +333,20 @@ class ResNest:
         if self.using_basic_block is True:
             x = self._make_block_basic(x, first_block=True, filters=filters, stride=stride, radix=self.radix,
                                        avd=self.avd, avd_first=self.avd_first, is_first=is_first)
-            # print('0',x.shape)
 
             for i in range(1, blocks):
                 x = self._make_block_basic(
                     x, first_block=False, filters=filters, stride=1, radix=self.radix, avd=self.avd, avd_first=self.avd_first
                 )
-                # print(i,x.shape)
 
         elif self.using_basic_block is False:
             x = self._make_block(x, first_block=True, filters=filters, stride=stride, radix=self.radix, avd=self.avd,
                                  avd_first=self.avd_first, is_first=is_first)
-            # print('0',x.shape)
 
             for i in range(1, blocks):
                 x = self._make_block(
                     x, first_block=False, filters=filters, stride=1, radix=self.radix, avd=self.avd, avd_first=self.avd_first
                 )
-                # print(i,x.shape)
         return x
 
     def _make_Composite_layer(self, input_tensor, filters=256, kernel_size=1, stride=1, upsample=True):
@@ -403,24 +401,25 @@ class ResNest:
             if self.verbose:
                 print('----- layer {} out {} -----'.format(idx, x.shape))
 
-        x = GlobalAveragePooling2D(name='avg_pool')(x)
+        if self.include_top:
+            x = GlobalAveragePooling2D(name='avg_pool')(x)
+            if self.verbose:
+                print("pool_out:", x.shape)  # remove the concats var
+
+            if self.dropout_rate > 0:
+                x = Dropout(self.dropout_rate, noise_shape=None)(x)
+
+            x = Dense(self.nb_classes, kernel_initializer="he_normal", use_bias=False, name="fc_NObias")(x)  # replace concats to x
+            if self.verbose:
+                print("fc_out:", x.shape)
+
+            if self.fc_activation:
+                x = Activation(self.fc_activation)(x)
+
+        model = models.Model(inputs=input_sig, outputs=x)
+
         if self.verbose:
-            print("pool_out:", x.shape)  # remove the concats var
-
-        if self.dropout_rate > 0:
-            x = Dropout(self.dropout_rate, noise_shape=None)(x)
-
-        fc_out = Dense(self.nb_classes, kernel_initializer="he_normal", use_bias=False, name="fc_NObias")(x)  # replace concats to x
-        if self.verbose:
-            print("fc_out:", fc_out.shape)
-
-        if self.fc_activation:
-            fc_out = Activation(self.fc_activation)(fc_out)
-
-        model = models.Model(inputs=input_sig, outputs=fc_out)
-
-        if self.verbose:
-            print("Resnest builded with input {}, output{}".format(input_sig.shape, fc_out.shape))
+            print("Resnest builded with input {}, output{}".format(input_sig.shape, x.shape))
             print("-------------------------------------------")
             print("")
 
@@ -428,10 +427,10 @@ class ResNest:
 
 
 def resnest(model_name='ResNest50', height=224, width=224, nb_classes=81,
-            verbose=False, dropout_rate=0, fc_activation=None, **kwargs):
+            verbose=False, dropout_rate=0, fc_activation='softmax', include_top=True, **kwargs):
     '''fetch_resnest
     input_shape: (h,w,c)
-    fc_activation: sigmoid,softmax
+    fc_activation: sigmoid, softmax
     '''
     model_name = model_name.lower()
 
@@ -461,7 +460,7 @@ def resnest(model_name='ResNest50', height=224, width=224, nb_classes=81,
             blocks_set=resnest_parameters[model_name]['blocks_set'],
             radix=2, groups=1, bottleneck_width=64, deep_stem=True,
             stem_width=resnest_parameters[model_name]['stem_width'],
-            avg_down=True, avd=True, avd_first=False, **kwargs
+            avg_down=True, avd=True, avd_first=False, include_top=include_top, **kwargs
         ).build()
 
     return model


### PR DESCRIPTION
## 概要
- DeeplabのbackboneにResNeStを選べるようにしました
- resnest50, resnest101, resnest200 が選べます

## 変更点
- DilatedXceptionの名前をDeeplabV3+論文に習ってAlignedXceptionに変更
- resnestの引数に `include_top` , `return_skip` , `dilated` を追加
    - `includer_top` はfc層をつけるかどうか（segmentationの時は `include_top=False` ）
    - `return_skip` は低レベルの特徴マップを返すかどうか(deeplabのモデルでは `return_skip=True` )
    - `dilated` は途中のConvをAtrousConv（DilationConv）にするかどうか（segmentationの時は `dilated=True` ）
- Deeplabのbackboneにresnestの分岐を追加

## 問題点・懸念点
- pytorchのDeeplabV3-ResNeStの実装を見ると低レベルの特徴の接続がなさそうだけど、追加してみました
- resnest(dilated=True)にすると出力が(16, 16, 2048) -> (128, 128, 2048)となり、デコーダの低レベル特徴マップとAddする際に、画像サイズを合わせるためのBilinearUpsampingが必要なくなってしまった
    - 通常、エンコーダで入力サイズが1/16され、デコーダで4倍（ここで低レベル特徴マップと接続）× 4倍されるが、resnest(dilated=True)にするとエンコーダで1/4、デコーダで4倍となる