### PR TITLE
Flooding

### DIFF
--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -52,7 +52,7 @@ def flooding(loss, b=0.02):
     arXiv: https://arxiv.org/pdf/2002.08709.pdf
     b is flooding level {0.00, 0.01, 0.02, ..., 0.20}
     """
-    return (loss - b).abs() + b
+    return tf.math.abs(loss - b) + b
 
 
 def _tp_fp_fn(gt, pr):

--- a/farmer/ncc/losses/functional.py
+++ b/farmer/ncc/losses/functional.py
@@ -47,6 +47,14 @@ def log_cosh_focal_tversky_loss(gt, pr, alpha=0.3, beta=0.7, gamma=1.3, class_we
     return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
 
 
+def flooding(loss, b=0.02):
+    """Flooding
+    arXiv: https://arxiv.org/pdf/2002.08709.pdf
+    b is flooding level {0.00, 0.01, 0.02, ..., 0.20}
+    """
+    return (loss - b).abs() + b
+
+
 def _tp_fp_fn(gt, pr):
     pr = tf.clip_by_value(pr, SMOOTH, 1 - SMOOTH)
     reduce_axes = [0, 1, 2]

--- a/farmer/ncc/losses/losses.py
+++ b/farmer/ncc/losses/losses.py
@@ -8,143 +8,154 @@ segmentation_models.set_framework('tf.keras')
 
 
 class DiceLoss(Loss):
-    def __init__(self, beta=1, class_weights=None):
+    def __init__(self, beta=1, class_weights=None, flooding_level=0.):
         super().__init__(name='dice_loss')
         self.beta = beta
         self.class_weights = class_weights if class_weights is not None else 1
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.dice_loss(
+        return F.flooding(F.dice_loss(
             gt=gt,
             pr=pr,
             beta=self.beta,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class JaccardLoss(Loss):
-    def __init__(self, class_weights=None):
+    def __init__(self, class_weights=None, flooding_level=0.):
         super().__init__(name='jaccard_loss')
         self.class_weights = class_weights if class_weights is not None else 1
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.jaccard_loss(
+        return F.flooding(F.jaccard_loss(
             gt=gt,
             pr=pr,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class TverskyLoss(Loss):
-    def __init__(self, alpha=0.45, beta=0.55, class_weights=None):
+    def __init__(self, alpha=0.45, beta=0.55, class_weights=None, flooding_level=0.):
         super().__init__(name='tversky_loss')
         self.alpha = alpha
         self.beta = beta
         self.class_weights = class_weights if class_weights is not None else 1.
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.tversky_loss(
+        return F.flooding(F.tversky_loss(
             gt=gt,
             pr=pr,
             alpha=self.alpha,
             beta=self.beta,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class FocalTverskyLoss(Loss):
-    def __init__(self, alpha=0.45, beta=0.55, gamma=2.5, class_weights=None):
+    def __init__(self, alpha=0.45, beta=0.55, gamma=2.5, class_weights=None, flooding_level=0.):
         super().__init__(name='focal_tversky_loss')
         self.alpha = alpha
         self.beta = beta
         self.gamma = gamma
         self.class_weights = class_weights if class_weights is not None else 1.
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.focal_tversky_loss(
+        return F.flooding(F.focal_tversky_loss(
             gt=gt,
             pr=pr,
             alpha=self.alpha,
             beta=self.beta,
             gamma=self.gamma,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class CategoricalFocalLoss(Loss):
-    def __init__(self, alpha=0.25, gamma=2., class_weights=None):
+    def __init__(self, alpha=0.25, gamma=2., class_weights=None, flooding_level=0.):
         super().__init__(name='categorical_focal_loss')
         self.alpha = alpha
         self.gamma = gamma
         self.class_weights = class_weights if class_weights is not None else 1.
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.categorical_focal_loss(
+        return F.flooding(F.categorical_focal_loss(
             gt,
             pr,
             alpha=self.alpha,
             gamma=self.gamma,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class LogCoshDiceLoss(Loss):
-    def __init__(self, beta=1, class_weights=None):
+    def __init__(self, beta=1, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_dice_loss')
         self.beta = beta
         self.class_weights = class_weights if class_weights is not None else 1
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.log_cosh_dice_loss(
+        return F.flooding(F.log_cosh_dice_loss(
             gt=gt,
             pr=pr,
             beta=self.beta,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class LogCoshTverskyLoss(Loss):
-    def __init__(self, alpha=0.3, beta=0.7, class_weights=None):
+    def __init__(self, alpha=0.3, beta=0.7, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_tversky_loss')
         self.alpha = alpha
         self.beta = beta
         self.class_weights = class_weights if class_weights is not None else 1.
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.log_cosh_tversky_loss(
+        return F.flooding(F.log_cosh_tversky_loss(
             gt=gt,
             pr=pr,
             alpha=self.alpha,
             beta=self.beta,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class LogCoshFocalTverskyLoss(Loss):
-    def __init__(self, alpha=0.3, beta=0.7, gamma=1.3, class_weights=None):
+    def __init__(self, alpha=0.3, beta=0.7, gamma=1.3, class_weights=None, flooding_level=0.):
         super().__init__(name='log_cosh_focal_tversky_loss')
         self.alpha = alpha
         self.beta = beta
         self.gamma = gamma
         self.class_weights = class_weights if class_weights is not None else 1.
+        self.flooding_level = flooding_level
 
     def __call__(self, gt, pr):
-        return F.log_cosh_focal_tversky_loss(
+        return F.flooding(F.log_cosh_focal_tversky_loss(
             gt=gt,
             pr=pr,
             alpha=self.alpha,
             beta=self.beta,
             gamma=self.gamma,
             class_weights=self.class_weights
-        )
+        ), self.flooding_level)
 
 
 class LogCoshLoss(Loss):
-    def __init__(self, base_loss, **kwargs):
+    def __init__(self, base_loss, flooding_level=0., **kwargs):
         super().__init__(name=f'log_cosh_{base_loss}')
         self.loss = getattr(F, base_loss)
+        self.flooding_level = flooding_level
         self.kwargs = kwargs
 
     def __call__(self, gt, pr):
         x = self.loss(gt, pr, **self.kwargs)
-        return tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0)
+        return F.flooding(
+            tf.math.log((tf.exp(x) + tf.exp(-x)) / 2.0),
+            self.flooding_level)


### PR DESCRIPTION
## 概要
"Do We Need Zero Training Loss After Achieving Zero Training Error?"
https://arxiv.org/pdf/2002.08709.pdf
- 正則化手法の1つ
- train_lossに `flooding_level` のバイアスを加える
- `flooding_level` は0~0.20まで0.01刻み

segmentation.yaml
```yaml
    loss:
      functions:
        CategoricalFocalLoss:
            flooding_level: 0.05
```

segmentation_optuna.yaml
```yaml
    loss:
        functions:
            DiceLoss:
                flooding_level:
                    - 0.00
                    - 0.20
                    - 0.01
```

## 変更点
- 全てのLossクラスにfloodingをwrapしました
- flooding_level=0の時、普通のlossと同じ（はず）
    - 正確にはlossの絶対値が取られますが、lossが負の値じゃないなら問題ないはず

## 問題点
- lossをwrapする書き方が冗長かもしれません
